### PR TITLE
feat!: implement a support for firefox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  build-chrome:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -22,14 +22,41 @@ jobs:
         run: npm ci
         
       - name: Build project
-        run: npm run build
+        run: npm run build:chrome
         
       - name: Rename dist folder
         run: |
-          mv dist anime4k-webextension
+          mv dist-chrome anime4k-webextension
           
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: anime4k-webextension
+          name: anime4k-webextension-chrome
+          path: anime4k-webextension
+
+  build-firefox:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build project
+        run: npm run build:firefox
+        
+      - name: Rename dist folder
+        run: |
+          mv dist-firefox anime4k-webextension
+          
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: anime4k-webextension-firefox
           path: anime4k-webextension

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ dist
 *.crx
 *.pem
 /img
+/dist*

--- a/manifest.json
+++ b/manifest.json
@@ -14,13 +14,7 @@
   },
   "options_page": "options.html",
   "background": {
-    "service_worker": "background.js",
-    "scripts": ["background.js"]
-  },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "@anime4k-web-extension.chenmozhijin"
-    }
+    "service_worker": "background.js"
   },
   "content_scripts": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anime4k-webextension",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anime4k-webextension",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "dependencies": {
         "anime4k-webgpu": "^1.0.0"
       },
@@ -14,6 +14,7 @@
         "@types/chrome": "^0.0.326",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^13.0.0",
+        "cross-env": "^7.0.3",
         "css-loader": "^7.1.2",
         "html-webpack-plugin": "^5.5.4",
         "mini-css-extract-plugin": "^2.9.2",
@@ -742,6 +743,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,18 @@
   "version": "0.3.0",
   "description": "Real-time video super-resolution browser extension based on Anime4K.",
   "scripts": {
-    "build": "webpack --mode production",
-    "dev": "webpack --mode development",
-    "watch": "webpack --mode development --watch"
+    "build": "npm run build:chrome",
+    "build:chrome": "cross-env TARGET_BROWSER=chrome webpack --mode production",
+    "build:firefox": "cross-env TARGET_BROWSER=firefox webpack --mode production",
+    "dev": "npm run dev:chrome",
+    "dev:chrome": "cross-env TARGET_BROWSER=chrome webpack --mode development",
+    "dev:firefox": "cross-env TARGET_BROWSER=firefox webpack --mode development",
+    "watch:chrome": "cross-env TARGET_BROWSER=chrome webpack --mode development --watch",
+    "watch:firefox": "cross-env TARGET_BROWSER=firefox webpack --mode development --watch"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.326",
+    "cross-env": "^7.0.3",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^13.0.0",
     "css-loader": "^7.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,25 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ExtensionManifestPlugin = require('webpack-extension-manifest-plugin');
-const packageJson = require('./package.json');
-const { clear } = require('console');
 
 module.exports = (env, argv) => {
   const isDevelopment = argv.mode === 'development';
+  const targetBrowser = process.env.TARGET_BROWSER || 'chrome';
+
+  const manifest = require('./manifest.json');
+  
+  // 据目标浏览器修改 manifest
+  if (targetBrowser === 'firefox') {
+      // Firefox 特定的转换
+      delete manifest.background.service_worker;
+      manifest.background.scripts = ['background.js'];
+      manifest.browser_specific_settings = {
+        gecko: {
+          id: '@anime4k-web-extension.chenmozhijin',
+        },
+      };
+    }
+
   
   return {
     entry: {
@@ -20,7 +34,7 @@ module.exports = (env, argv) => {
     },
     output: {
       filename: '[name].js',
-      path: path.resolve(__dirname, 'dist'),
+      path: path.resolve(__dirname, 'dist-' + targetBrowser),
       clean: true, // 清理输出目录
     },
     module: {
@@ -66,8 +80,7 @@ module.exports = (env, argv) => {
       }),
       new ExtensionManifestPlugin({
         config: {
-          base: './manifest.json',
-
+          base: manifest,
         },
         pkgJsonProps: [
           'version'


### PR DESCRIPTION
Changed a manifest file and sources for the `copyExternalImageToTexture` method

Tested on Firefox:

![firefox_mDBd9bM0wm](https://github.com/user-attachments/assets/35817f28-72fe-49f4-9474-b4ba4aff6dd0)
![firefox_xBoi2yFHKM](https://github.com/user-attachments/assets/8e643894-a0e7-416e-8e2d-7a51245fee23)

<img width="1920" height="1040" alt="firefox_MuLfVwcbJF" src="https://github.com/user-attachments/assets/adb182fe-03e0-451d-97af-6b414bed32ba" />
<img width="1920" height="1040" alt="firefox_oRFBQCpXT1" src="https://github.com/user-attachments/assets/11be9995-1631-4796-8376-ee9459d8d21a" />

Tested on Chrome:

<img width="1920" height="927" alt="chrome_BFkcbnQ3Gb" src="https://github.com/user-attachments/assets/415fac18-90da-4c2e-a7c6-c663847826ef" />
<img width="1920" height="927" alt="chrome_E3eJkmqbss" src="https://github.com/user-attachments/assets/780eb6f2-7cb8-4381-bd77-a71ea4f6dccd" />
